### PR TITLE
142 branch

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -7,11 +7,7 @@
 
 0 errors | 0 warnings | 0 notes
 
-New submission
-
-* This is a new release.
-
 ## Reverse dependencies
 
-This is a new release, so there are no reverse dependencies.
+There is one reverse dependency: moderndive. No problems found.
 

--- a/tests/testthat/test-specify.R
+++ b/tests/testthat/test-specify.R
@@ -7,18 +7,12 @@ mtcars <- as.data.frame(mtcars) %>%
                 gear = factor(gear),
                 carb = factor(carb))
 
-test_that("specify"), {
-  
-  expect_is(data.frame)
-  
-})
-
-
 test_that("data argument", {
 
   expect_error(specify(blah ~ cyl))
   expect_error(specify(1:3))
-
+  expect_is(mtcars, "data.frame")
+  expect_error(specify(mtcars, mtcars$mpg))
 })
 
 test_that("response and explanatory arguments", {

--- a/tests/testthat/test-specify.R
+++ b/tests/testthat/test-specify.R
@@ -7,6 +7,13 @@ mtcars <- as.data.frame(mtcars) %>%
                 gear = factor(gear),
                 carb = factor(carb))
 
+test_that("specify"), {
+  
+  expect_is(data.frame)
+  
+})
+
+
 test_that("data argument", {
 
   expect_error(specify(blah ~ cyl))


### PR DESCRIPTION
Saw 'help wanted' to write test_that.

Added two very simple tests to test-specify.R, which I tied to issue #142 .
Not sure useful at all.   Was hoping to eliminate `assertive::assert_is_data.frame(x)` in specify.R

Found your code very succinct.   Packages like "methods::" that take me a while to work through.
Upshot:   if you can give me a bit of direction I'd like to see if I can be useful to writing tests.
No hard feelings if not.   
Thx.
jim
