### PR TITLE
Remove DEV vignettes

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -13,11 +13,6 @@ navbar:
       href: articles/flights_examples.html
     - text: Examples using `mtcars`
       href: articles/mtcars_examples.html
-# Remove these DEV vignettes when going to master branch/CRAN      
-    - text: (DEV) Simulation-Based `okcupiddata` Examples
-      href: articles/profiles_examples.html
-    - text: (DEV) Simulation-Based and Traditional `okcupiddata` Examples
-      href: articles/profiles_examples_both_methods.html
   - text: Reference
     href: reference/index.html      
   - text: News


### PR DESCRIPTION
@andrewpbray I forgot to remove the okcupiddata vignettes from the pkgdown build so the links at infer.netlify.com are broken. This should remove it on the travis build to gh-pages.